### PR TITLE
Add java.util.Function wrapper

### DIFF
--- a/src/main/java/com/github/ylegat/uncheck/Uncheck.java
+++ b/src/main/java/com/github/ylegat/uncheck/Uncheck.java
@@ -93,16 +93,6 @@ public class Uncheck {
      * @return a wrapper around the transformation function that handles exceptions in a lambda-friendly way.
      */
     public static <T, R> Function<T, R> uncheck(CheckedFunction<T, R> transformer) {
-        return value -> {
-            try {
-                return transformer.apply(value);
-            } catch (RuntimeException e) {
-                throw e;
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        };
+        return value -> uncheck(() -> transformer.apply(value));
     }
 }

--- a/src/main/java/com/github/ylegat/uncheck/Uncheck.java
+++ b/src/main/java/com/github/ylegat/uncheck/Uncheck.java
@@ -2,6 +2,7 @@ package com.github.ylegat.uncheck;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.function.Function;
 
 public class Uncheck {
 
@@ -24,6 +25,14 @@ public class Uncheck {
     @FunctionalInterface
     public interface CheckedOperation {
         void execute() throws Exception;
+    }
+
+    /**
+     * Represents an operation that returns no result.
+     */
+    @FunctionalInterface
+    public interface CheckedFunction<T, R> {
+        R apply(T param) throws Exception;
     }
 
     /**
@@ -67,5 +76,33 @@ public class Uncheck {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * <p>Wrap a transformation function.</p>
+     * <p>Exceptions are handled this way:</p>
+     * <ul>
+     * <li>RuntimeException are just propagated</li>
+     * <li>IOException are wrapped inside UncheckedIOException</li>
+     * <li>Other exceptions are wrapped inside RuntimeException</li>
+     * </ul>
+     *
+     * @param transformer the transformation function to apply
+     * @param <T>      the parameter type of the transformation function
+     * @param <R>      the result type of the transformation function
+     * @return a wrapper around the transformation function that handles exceptions in a lambda-friendly way.
+     */
+    public static <T, R> Function<T, R> uncheck(CheckedFunction<T, R> transformer) {
+        return value -> {
+            try {
+                return transformer.apply(value);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
     }
 }

--- a/src/test/java/com/github/ylegat/uncheck/UncheckTest.java
+++ b/src/test/java/com/github/ylegat/uncheck/UncheckTest.java
@@ -81,7 +81,7 @@ public class UncheckTest {
     }
 
     @Test
-    public void should_create_unchecked_io_exception_from_operation_execution_checked_exception() {
+    public void should_create_runtime_exception_from_operation_execution_checked_exception() {
         // Given
         Exception exception = new Exception();
         CheckedOperation operation = () -> {

--- a/src/test/java/com/github/ylegat/uncheck/UncheckTest.java
+++ b/src/test/java/com/github/ylegat/uncheck/UncheckTest.java
@@ -6,6 +6,9 @@ import static com.github.ylegat.uncheck.Uncheck.uncheck;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import com.github.ylegat.uncheck.Uncheck.CheckedFunction;
 import org.junit.Test;
 import com.github.ylegat.uncheck.Uncheck.CheckedOperation;
 import com.github.ylegat.uncheck.Uncheck.CheckedSupplier;
@@ -31,6 +34,19 @@ public class UncheckTest {
 
         // Then
         assertThat(atomicBoolean.get()).isTrue();
+    }
+
+    @Test
+    public void should_transform_value() {
+        // Given
+        Integer value = 42;
+        Function<Integer, String> uncheckedTransform = uncheck(String::valueOf);
+
+        // When
+        String transformedValue = uncheckedTransform.apply(value);
+
+        // Then
+        assertThat(transformedValue).isEqualTo(String.valueOf(value));
     }
 
     @Test
@@ -80,4 +96,48 @@ public class UncheckTest {
                              .hasCause(exception);
     }
 
+    @Test
+    public void should_propagate_runtime_exception_from_transformation_application() {
+        // Given
+        RuntimeException runtimeException = new RuntimeException();
+        CheckedFunction<Integer, Object> transform = any -> {
+            throw runtimeException;
+        };
+
+        // When
+        Throwable throwable = catchThrowable(() -> uncheck(transform).apply(42));
+
+        // Then
+        assertThat(throwable).isSameAs(runtimeException);
+    }
+
+    @Test
+    public void should_create_unchecked_io_exception_from_transformation_application_io_exception() {
+        // Given
+        IOException ioException = new IOException();
+        CheckedFunction<Integer, Object> transform = any -> {
+            throw ioException;
+        };
+
+        // When
+        Throwable throwable = catchThrowable(() -> uncheck(transform).apply(42));
+
+        // Then
+        assertThat(throwable).isInstanceOf(UncheckedIOException.class).hasCause(ioException);
+    }
+
+    @Test
+    public void should_create_runtime_exception_from_transformation_application_checked_exception() {
+        // Given
+        Exception exception = new Exception();
+        CheckedFunction<Integer, Object> transform = any -> {
+            throw exception;
+        };
+
+        // When
+        Throwable throwable = catchThrowable(() -> uncheck(transform).apply(42));
+
+        // Then
+        assertThat(throwable).isInstanceOf(RuntimeException.class).hasCause(exception);
+    }
 }

--- a/src/test/java/com/github/ylegat/uncheck/UncheckTest.java
+++ b/src/test/java/com/github/ylegat/uncheck/UncheckTest.java
@@ -11,7 +11,6 @@ import java.util.function.Function;
 import com.github.ylegat.uncheck.Uncheck.CheckedFunction;
 import org.junit.Test;
 import com.github.ylegat.uncheck.Uncheck.CheckedOperation;
-import com.github.ylegat.uncheck.Uncheck.CheckedSupplier;
 
 public class UncheckTest {
 


### PR DESCRIPTION
The idea behind this PR is to allow someone to write something akin to:

``` java
Stream.of("a", "b", "c")
    .map(uncheck(this::someMethodThatThrowsSomeCheckedException))
    .forEach(System.out::println); // Or something more meaningful...
```
